### PR TITLE
#4: Add rule for lambda parameters

### DIFF
--- a/csharp.md
+++ b/csharp.md
@@ -188,6 +188,27 @@ int counter = ...;
 ```
 </details>
 
+<details>
+    <summary><b>Simplify single lambda expression parameter name, use full names for multiple parameters</b></summary>
+
+**Do** For one argument - always use `x`, for more than one - give full meaningful names:
+
+**Bad**
+
+```csharp
+i => …;
+item => …;
+(x, y) => …;
+```
+
+**Good**
+
+```csharp
+x => …;
+(key, value) => …;
+```
+</details>
+
 ### Coding conventions
 
 <details>


### PR DESCRIPTION
Related to #4.

If I remember correctly, it is the rule we decided to use for lambda expression parameters.
For single parameter - always `x`, full meaningful names for multiple parameters.

We are using this logic currently in most of the cases, it is straightforward and simple. In the majority of cases, we even do not need to think about the variable name.